### PR TITLE
add checks to avoid errors when empty/short stack trace

### DIFF
--- a/lib/coffee-trace.coffee
+++ b/lib/coffee-trace.coffee
@@ -25,7 +25,7 @@ module.exports = coffee_trace = (newOptions = {})->
 
   process.on 'uncaughtException', (err) ->
     margin = 3  # Shown lines before and after trace line.
-    coffee_trace = (stack = err.stack.split("\n"))[1].match(options.stack_matcher) or []
+    coffee_trace = (stack = err.stack.split("\n"))[1]?.match(options.stack_matcher) or []
     filename = coffee_trace[1]
     line_num = Number(coffee_trace[2])
     line_col = Number(coffee_trace[3])
@@ -79,7 +79,7 @@ module.exports = coffee_trace = (newOptions = {})->
 
       spaces = new Array(Math.round(max_line_length / 2)).join(" ")
 
-    stack[1] = stack[1].replace(/\.coffee:/, ".js:")
+    stack[1] = stack[1]?.replace(/\.coffee:/, ".js:")
     console.error "\x1b[0m\n", stack.join("\n")
     console.error()
     process.exit()


### PR DESCRIPTION
So I'm not sure why this happens, or even how to reproduce, but every now and then I'll get an error like the following:

```
/Users/jesse/Projects/whatever/node_modules/coffee-trace/lib/coffee-trace.coffee:17
      coffee_trace = (stack = err.stack.split("\n"))[1].match(/^ +at[^\/]+((?:
                                                        ^
TypeError: Cannot call method 'match' of undefined
    at process.<anonymous> (/Users/jesse/Projects/whatever/node_modules/coffee-trace/lib/coffee-trace.coffee:17:57)
    at process.EventEmitter.emit (events.js:117:20)
    at process._fatalException (node.js:272:26)
```

Checking to make sure the array index exists before calling `.match` or `.replace` seems to fix the problem...
